### PR TITLE
fix shortcuts and events

### DIFF
--- a/ContentScript/TextBox.js
+++ b/ContentScript/TextBox.js
@@ -48,6 +48,10 @@ function TextBox(id, className, textParams, params) {
     this.box.addEventListener("mouseover", this.applyBoxOpacity.bind(this), true);
     this.box.addEventListener("mouseout", this.applyBoxOpacity.bind(this), true);
 
+    this.box.addEventListener("keypress", function(e) { e.stopPropagation(); });
+    this.box.addEventListener("keydown", function(e) { e.stopPropagation(); });
+    this.box.addEventListener("keyup", function(e) { e.stopPropagation(); });
+
     this.draw();
     //Initialize values if provided
     //if (params) {

--- a/README.md
+++ b/README.md
@@ -101,3 +101,8 @@ Version 2.1.1:
 - Fixed an issue with the media notes.
 - Config page refactored.
 - Added shortcuts and the feature to customize them.
+
+Version 2.1.2:
+
+- Stop propagation of kay events in textbox.
+- Shortcuts have been updated as some of them were mapped to other actions.

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
     "manifest_version": 2,
     "name": "__MSG_extensionName__",
     "description": "__MSG_extensionDescription__",
-    "version": "2.1.1",
+    "version": "2.1.2",
     "default_locale": "es",
 
     "background": {
@@ -83,27 +83,27 @@
             "description": "Creates a video annotation"
         },
         "sticky": {
-            "suggested_key": { "default": "Ctrl+Shift+S" },
+            "suggested_key": { "default": "Ctrl+Alt+S" },
             "description": "Creates an sticky annotation"
         },
         "url": {
-            "suggested_key": { "default": "Ctrl+Shift+K" },
+            "suggested_key": { "default": "Ctrl+Alt+K" },
             "description": "Creates a url annotation"
         },
         "highlight": {
-            "suggested_key": { "default": "Ctrl+Shift+H" },
+            "suggested_key": { "default": "Ctrl+Alt+H" },
             "description": "Creates a highlight annotation"
         },
         "changeText": {
-            "suggested_key": { "default": "Ctrl+Shift+C" },
+            "suggested_key": { "default": "Ctrl+Alt+C" },
             "description": "Creates a changeText annotation"
         },
         "underline": {
-            "suggested_key": { "default": "Ctrl+Shift+U" },
+            "suggested_key": { "default": "Ctrl+Alt+U" },
             "description": "Creates a underline annotation"
         },
         "crossout": {
-            "suggested_key": { "default": "Ctrl+Shift+X" },
+            "suggested_key": { "default": "Ctrl+Alt+X" },
             "description": "Creates a crossout annotation"
         }
 


### PR DESCRIPTION
#24 Issue fixed in code. Now, keys pressed inside a text annotation won´t trigger the event outside the annotation.
#12 Updated some default shortcuts because they were being used by Firefox